### PR TITLE
fix index documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python
 
 ```
 # example usage:
-from I2T2.manipulate import *
+from I2T2.io import *
 import matplotlib.pyplot as plt
 
 data_path = '../data/knee/'

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,7 +116,7 @@ conda install -c conda-forge gdcm</code></pre>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># example usage:</span>
-<span class="kn">from</span> <span class="nn">I2T2.manipulate</span> <span class="kn">import</span> <span class="o">*</span>
+<span class="kn">from</span> <span class="nn">I2T2.io</span> <span class="kn">import</span> <span class="o">*</span>
 <span class="kn">import</span> <span class="nn">matplotlib.pyplot</span> <span class="k">as</span> <span class="nn">plt</span>
 
 <span class="n">data_path</span> <span class="o">=</span> <span class="s1">&#39;../data/knee/&#39;</span>
@@ -138,7 +138,8 @@ conda install -c conda-forge gdcm</code></pre>
 <div class="output_area">
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>could not load array
+<pre>path to dicom failed
+could not load array
 </pre>
 </div>
 </div>

--- a/docs/manipulate.html
+++ b/docs/manipulate.html
@@ -187,7 +187,7 @@ description: "Manipulate performs common image transformations such as cropping,
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="pad" class="doc_header"><code>pad</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L65" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>pad</code>(<strong><code>image_array</code></strong>, <strong><code>final_dims_in_pixels</code></strong>, <strong><code>zero_fill_mode</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="pad" class="doc_header"><code>pad</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L67" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>pad</code>(<strong><code>image_array</code></strong>, <strong><code>final_dims_in_pixels</code></strong>, <strong><code>zero_fill_mode</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Pad image data to final_dim_in_pixels</p>
 <p>Attributes:
@@ -297,7 +297,7 @@ description: "Manipulate performs common image transformations such as cropping,
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="resample" class="doc_header"><code>resample</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L112" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>resample</code>(<strong><code>image_array</code></strong>, <strong><code>goal_pixel_dims_list</code></strong>, <strong><code>is_seg</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="resample" class="doc_header"><code>resample</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L118" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>resample</code>(<strong><code>image_array</code></strong>, <strong><code>goal_pixel_dims_list</code></strong>, <strong><code>is_seg</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Resamples <code>image</code> to new resolution according to a compression factor using scipy's <code>ndimage</code></p>
 <p>Attributes:
@@ -335,7 +335,7 @@ description: "Manipulate performs common image transformations such as cropping,
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="resample_by" class="doc_header"><code>resample_by</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L139" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>resample_by</code>(<strong><code>image_array</code></strong>, <strong><code>compression_factor_list</code></strong>, <strong><code>is_seg</code></strong>=<em><code>False</code></em>)</p>
+<h4 id="resample_by" class="doc_header"><code>resample_by</code><a href="https://github.com/pfdamasceno/I2T2/tree/master/I2T2/manipulate.py#L149" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>resample_by</code>(<strong><code>image_array</code></strong>, <strong><code>compression_factor_list</code></strong>, <strong><code>is_seg</code></strong>=<em><code>False</code></em>)</p>
 </blockquote>
 <p>Resamples <code>image</code> to new resolution according to a compression factor using scipy's <code>ndimage</code></p>
 <p>Attributes:

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -130,7 +130,7 @@
    ],
    "source": [
     "# example usage:\n",
-    "from I2T2.manipulate import *\n",
+    "from I2T2.io import *\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "data_path = '../data/knee/'\n",
@@ -141,6 +141,13 @@
     "except:\n",
     "    print('could not load array')    "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Documentation index page used to have old `manipulate` for `load_dcm` function. Now this is on `io`