### PR TITLE
Hotfix kramdown & python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       with:
         activate-conda: true
-        python_version: 3.7.8
+        python-version: 3.7.8
     - run: conda --version
     - run: which python
     - shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       with:
         activate-conda: true
-        python-version: 3.7.8
+        python-version: 3.7
     - run: conda --version
     - run: which python
     - shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       with:
         activate-conda: true
+        python_version: 3.7.8
     - run: conda --version
     - run: which python
     - shell: bash -l {0}

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       jekyll-theme-time-machine (= 0.1.1)
       jekyll-titles-from-headings (= 0.5.1)
       jemoji (= 0.10.2)
-      kramdown (= 1.17.0)
+      kramdown (= 2.3.0)
       liquid (= 4.0.0)
       listen (= 3.1.5)
       mercenary (~> 0.3)
@@ -192,7 +192,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
     liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -245,6 +245,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll (~> 3.7)
+  kramdown (>= 2.3.0)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Bug fixes:
- vulnerability with kramdown version (updated to 2.3+)
- problem with conda python version (conda was using py3.8 which is not yet supported by `gdcm`)